### PR TITLE
Team3-dev <---- #212 Fix Car Sliding

### DIFF
--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/AutomatedCar.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/AutomatedCar.java
@@ -3,16 +3,14 @@ package hu.oe.nik.szfmv.automatedcar;
 import hu.oe.nik.szfmv.automatedcar.math.Axis;
 import hu.oe.nik.szfmv.automatedcar.math.IVector;
 import hu.oe.nik.szfmv.automatedcar.model.WorldObject;
-import hu.oe.nik.szfmv.automatedcar.powertrain.CarTransmissionMode;
+import hu.oe.nik.szfmv.automatedcar.move.CarMover;
 import hu.oe.nik.szfmv.automatedcar.powertrain.PowerTrain;
 import hu.oe.nik.szfmv.automatedcar.systemcomponents.Driver;
 import hu.oe.nik.szfmv.automatedcar.virtualfunctionbus.DependentVirtualFunctionBus;
 import hu.oe.nik.szfmv.automatedcar.virtualfunctionbus.VirtualFunctionBus;
-import hu.oe.nik.szfmv.automatedcar.virtualfunctionbus.packets.powertrain.ICarMovePacket;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import static hu.oe.nik.szfmv.automatedcar.math.IVector.average;
 import static hu.oe.nik.szfmv.automatedcar.math.IVector.vectorFromXY;
 import static java.lang.Math.round;
 
@@ -24,7 +22,6 @@ public class AutomatedCar extends WorldObject {
     /**Host for information interchange between components of the car via packets.*/
     private final DependentVirtualFunctionBus virtualFunctionBus = new DependentVirtualFunctionBus();
 
-    /**@see PowerTrain*/
     private final PowerTrain powerTrain = new PowerTrain(virtualFunctionBus);
 
     /**Not necessarily a unit vector, can have any length.*/
@@ -34,6 +31,8 @@ public class AutomatedCar extends WorldObject {
         super(x, y, imageFileName);
 
         new Driver(virtualFunctionBus);
+        new CarMover(virtualFunctionBus, this);
+
         this.virtualFunctionBus.validateAllDependenciesSatisfied();
     }
 
@@ -41,8 +40,11 @@ public class AutomatedCar extends WorldObject {
         this(0, 0, variant.getImageResourceName());
     }
 
+    public IVector getFacingDirection() {
+        return facingDirection;
+    }
+
     public void drive() {
-        updatePositionAndOrientation();
         virtualFunctionBus.loop();
     }
 
@@ -71,76 +73,9 @@ public class AutomatedCar extends WorldObject {
         this.setY(y);
     }
 
-    /**@author Team 3*/
-    private void updatePositionAndOrientation() {
-        ICarMovePacket moveInfo = this.virtualFunctionBus.carMovePacket;
-        this.moveCar(moveInfo.getMoveVector());
-    }
-
-    /**Applies movement to the car, although not the given vector directly.
-     * Moves the car approximately in the direction of the given move also considering the rotation of the car.
-     * @param movement The movement to apply.
-     * <p>- its direction is interpreted as facing direction of the front wheels.</p>
-     * <p>- its length is interpreted as the speed of movement.</p>
-     * @author Team 3*/
-    private void moveCar(IVector movement) {
-        //TODO REMOVE DEBUG
-        if (movement.hasLength() && movement.getLength() > 0) {
-            System.out.printf("Relative to facing: %.4f°    (facing: (%.2f,%.2f) = %.4f° from -Y)",
-                    movement.getDegrees(), facingDirection.getXDiff(),
-                    facingDirection.getYDiff(),
-                    facingDirection.getDegreesRelativeTo(Axis.Y.negativeDirection()));
-            System.out.println();
-        }
-
-        IVector oldFacing = this.facingDirection;
-        IVector oldPosition = this.getPosition();
-        IVector toCarFrontVector = oldFacing.withLength(getHeight() / 2.0);
-        IVector oldCarFrontPosition = oldPosition.add(toCarFrontVector);
-        IVector oldCarBackPosition = oldPosition.subtract(toCarFrontVector);
-        IVector moveInWheelFacingDirection = movement.rotateByRadians(oldFacing.getRadians());
-        boolean reverseMode = powerTrain.transmission.getCurrentTransmissionMode() == CarTransmissionMode.R_REVERSE;
-
-        IVector newCarFrontPosition = oldCarFrontPosition.add(moveInWheelFacingDirection);
-        IVector newCarBackPosition = reverseMode
-                ? oldCarBackPosition.subtract(movement.withDirection(oldFacing))
-                : oldCarBackPosition.add(movement.withDirection(oldFacing));
-        IVector newPosition = average(newCarFrontPosition, newCarBackPosition);
-        IVector newFacing = newCarFrontPosition.subtract(newCarBackPosition);
-
-        this.setPosition(newPosition);
-        this.facingDirection = newFacing;
-        this.setRotation(newFacing.getRadiansRelativeTo(Axis.Y.negativeDirection()));
-
-        //TODO REMOVE DEBUG
-        if (movement.hasLength() && movement.getLength() > 0) {
-            System.out.printf("Move vector: %s",
-                    newPosition.subtract(oldPosition).printXY("(%.3f,%.3f)"));
-            System.out.println();
-        }
-
-        //TODO REMOVE DEBUG
-        if (movement.hasLength() && movement.getLength() > 0) {
-            System.out.printf("    Front Move vector: %s",
-                    newCarFrontPosition.subtract(oldCarFrontPosition).printXY("(%.3f,%.3f)"));
-            System.out.println();
-        }
-
-        //TODO REMOVE DEBUG
-        if (movement.hasLength() && movement.getLength() > 0) {
-            System.out.printf("    Back Move vector: %s",
-                    newCarBackPosition.subtract(oldCarBackPosition).printXY("(%.3f,%.3f)"));
-            System.out.println();
-        }
-
-        //TODO REMOVE DEBUG
-        if (movement.hasLength() && movement.getLength() > 0) {
-            System.out.printf("Move made: %.9f°,  oldPos:%s, newPos:%s",
-                    newPosition.subtract(oldPosition).getDegreesRelativeTo(oldFacing),
-                    oldPosition.printXY("(%.0f:%.0f)"),
-                    newPosition.printXY("(%.0f:%.0f)"));
-            System.out.println();
-        }
+    public void setFacingDirection(IVector direction) {
+        this.facingDirection = direction;
+        this.setRotation(direction.getRadiansRelativeTo(Axis.Y.negativeDirection()));
     }
 
 }

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/math/IVector.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/math/IVector.java
@@ -324,4 +324,8 @@ public interface IVector {
         return vectorFromXY(0, 0);
     }
 
+    default String printXY(String format) {
+        return String.format(format, this.getXDiff(), this.getYDiff());
+    }
+
 }

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/move/CarMoveCalculatorStrategy.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/move/CarMoveCalculatorStrategy.java
@@ -1,0 +1,35 @@
+package hu.oe.nik.szfmv.automatedcar.move;
+
+import hu.oe.nik.szfmv.automatedcar.AutomatedCar;
+import hu.oe.nik.szfmv.automatedcar.math.Axis;
+import hu.oe.nik.szfmv.automatedcar.math.IVector;
+
+/**@author Team 3 (Dávid Magyar | aether-fox | davidson996@gmail.com)*/
+abstract class CarMoveCalculatorStrategy {
+
+    protected abstract ICarLocation calculateMovement(AutomatedCar car, IVector movement);
+
+    /**@param movement The movement to apply.
+     * <p>- its direction is interpreted as facing direction of the front wheels.</p>
+     * <p>- its length is interpreted as the speed of movement.</p>*/
+    final void applyMovement(AutomatedCar car, IVector movement) {
+        ICarLocation newLocation = this.calculateMovement(car, movement);
+
+        car.setPosition(newLocation.getPosition());
+        car.setFacingDirection(newLocation.getFacing());
+        car.setRotation(newLocation.getFacing().getRadiansRelativeTo(Axis.Y.negativeDirection()));
+    }
+
+    /**Applies movement to the car, although not the given vector directly.
+     * Moves the car approximately in the direction of the given move also considering the rotation of the car.*/
+    static CarMoveCalculatorStrategy consideringBackWheels() {
+        return new CarMoveCalculatorStrategy() {
+            @Override
+            public ICarLocation calculateMovement(AutomatedCar car, IVector movement) {
+                CarMoveInput input = CarMoveInput.prepareForMovement(car, movement);
+                return CarMoveOutput.calculateMovement(input);
+            }
+        };
+    }
+
+}

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/move/CarMoveInput.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/move/CarMoveInput.java
@@ -1,0 +1,31 @@
+package hu.oe.nik.szfmv.automatedcar.move;
+
+import hu.oe.nik.szfmv.automatedcar.AutomatedCar;
+import hu.oe.nik.szfmv.automatedcar.math.IVector;
+import hu.oe.nik.szfmv.automatedcar.powertrain.CarTransmissionMode;
+
+/**@author Team 3 (Dávid Magyar | aether-fox | davidson996@gmail.com)*/
+final class CarMoveInput {
+    final IVector movement;
+    final IVector oldFacing;
+    final IVector oldCarFrontPosition;
+    final IVector oldCarBackPosition;
+    final IVector moveInWheelFacingDirection;
+    final boolean reverseMode;
+
+    private CarMoveInput(AutomatedCar car, IVector movement) {
+        this.movement = movement;
+        oldFacing = car.getFacingDirection();
+        IVector oldPosition = car.getPosition();
+        IVector toCarFrontVector = oldFacing.withLength(car.getHeight() / 2.0);
+        oldCarFrontPosition = oldPosition.add(toCarFrontVector);
+        oldCarBackPosition = oldPosition.subtract(toCarFrontVector);
+        moveInWheelFacingDirection = movement.rotateByRadians(oldFacing.getRadians());
+        reverseMode = car.getPowerTrain().getTransmission().getCurrentTransmissionMode() == CarTransmissionMode.R_REVERSE;
+    }
+
+    static CarMoveInput prepareForMovement(AutomatedCar car, IVector movement) {
+        return new CarMoveInput(car, movement);
+    }
+
+}

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/move/CarMoveOutput.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/move/CarMoveOutput.java
@@ -1,0 +1,36 @@
+package hu.oe.nik.szfmv.automatedcar.move;
+
+import hu.oe.nik.szfmv.automatedcar.math.IVector;
+
+import static hu.oe.nik.szfmv.automatedcar.math.IVector.average;
+
+/**@author Team 3 (Dávid Magyar | aether-fox | davidson996@gmail.com)*/
+final class CarMoveOutput implements ICarLocation {
+
+    final IVector newPosition;
+    final IVector newFacing;
+
+    private CarMoveOutput(CarMoveInput input) {
+        IVector newCarFrontPosition = input.oldCarFrontPosition.add(input.moveInWheelFacingDirection);
+        IVector newCarBackPosition = input.reverseMode
+                ? input.oldCarBackPosition.subtract(input.movement.withDirection(input.oldFacing))
+                : input.oldCarBackPosition.add(input.movement.withDirection(input.oldFacing));
+        newPosition = average(newCarFrontPosition, newCarBackPosition);
+        newFacing = newCarFrontPosition.subtract(newCarBackPosition);
+    }
+
+    static CarMoveOutput calculateMovement(CarMoveInput input) {
+        return new CarMoveOutput(input);
+    }
+
+    @Override
+    public IVector getPosition() {
+        return newPosition;
+    }
+
+    @Override
+    public IVector getFacing() {
+        return newFacing;
+    }
+
+}

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/move/CarMover.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/move/CarMover.java
@@ -1,0 +1,33 @@
+package hu.oe.nik.szfmv.automatedcar.move;
+
+import hu.oe.nik.szfmv.automatedcar.AutomatedCar;
+import hu.oe.nik.szfmv.automatedcar.powertrain.PowerTrain;
+import hu.oe.nik.szfmv.automatedcar.systemcomponents.SystemComponent;
+import hu.oe.nik.szfmv.automatedcar.virtualfunctionbus.DependsOn;
+import hu.oe.nik.szfmv.automatedcar.virtualfunctionbus.VirtualFunctionBus;
+
+import static hu.oe.nik.szfmv.automatedcar.move.CarMoveCalculatorStrategy.consideringBackWheels;
+
+/**@author Team 3 (Dávid Magyar | aether-fox | davidson996@gmail.com)*/
+@DependsOn(components = PowerTrain.class)
+public final class CarMover extends SystemComponent {
+
+    private final AutomatedCar car;
+    private final CarMoveCalculatorStrategy carMoveStrategy = consideringBackWheels();
+
+    public CarMover(VirtualFunctionBus virtualFunctionBus, AutomatedCar car) {
+        super(virtualFunctionBus);
+        this.car = car;
+    }
+
+    @Override
+    public void loop() {
+        updatePositionAndOrientation(this.car);
+    }
+
+    /**@author Team 3*/
+    private void updatePositionAndOrientation(AutomatedCar car) {
+        this.carMoveStrategy.applyMovement(car, this.virtualFunctionBus.carMovePacket.getMoveVector());
+    }
+
+}

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/move/ICarLocation.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/move/ICarLocation.java
@@ -1,0 +1,14 @@
+package hu.oe.nik.szfmv.automatedcar.move;
+
+import hu.oe.nik.szfmv.automatedcar.math.IVector;
+
+/**@author Team 3 (Dávid Magyar | aether-fox | davidson996@gmail.com)*/
+interface ICarLocation {
+
+    /**Position of the car as of X and Y coordinates.*/
+    IVector getPosition();
+
+    /**The facing direction of the car, so a vector pointing in the direction from the back of the car to its front.*/
+    IVector getFacing();
+
+}

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/powertrain/PowerTrain.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/powertrain/PowerTrain.java
@@ -21,12 +21,12 @@ import static java.lang.Math.*;
 @DependsOn(components = Driver.class)
 public class PowerTrain extends SystemComponent {
 
-    static final double MAX_WHEEL_ROTATION = 60.0;
+    private static final double MAX_WHEEL_ROTATION = 60.0;
     private static final double MAX_GAS_PEDAL_VALUE = 100.0;
     private static final double MAX_BREAK_PEDAL_VALUE = 100.0;
-    public static final double BREAK_POWER = 5.0;
+    private static final double BREAK_POWER = 5.0;
 
-    public ITransmission transmission = new SimpleTransmission();
+    private final SimpleTransmission transmission = new SimpleTransmission();
 
     private IVector currentMovement = nullVector();
     private IVector currentWheelDirection = nullVector();
@@ -37,6 +37,10 @@ public class PowerTrain extends SystemComponent {
     public PowerTrain(VirtualFunctionBus virtualFunctionBus) {
         super(virtualFunctionBus);
         this.provideInitialOutput();
+    }
+
+    public ITransmission getTransmission() {
+        return transmission;
     }
 
     private void provideInitialOutput() {

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/sensors/ParkingRadar.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/sensors/ParkingRadar.java
@@ -399,7 +399,7 @@ public class ParkingRadar extends SystemComponent {
     }
 
     private boolean isCarInReverse() {
-        return automatedCar.getPowerTrain().transmission.getCurrentTransmissionMode() == CarTransmissionMode.R_REVERSE;
+        return automatedCar.getPowerTrain().getTransmission().getCurrentTransmissionMode() == CarTransmissionMode.R_REVERSE;
     }
 }
 


### PR DESCRIPTION
# The Bug
While going in certain directions slowly, then the car clearly shifted towards one direction of the map.

# The Adventure
I spent tons of time figuring out what the hell is problematic with the expressions of the movement. I printed out tons of angles and vectors, still no clue. All seems completely fine and perfect. Yet, the car was sliding, and my hair was falling out. I was staring at the movement vector and all vectors representing the movement of the car... all was quite accurate. And then in a moment a spark of doubt fired up in my mind. What if... what if all vectors and all hellish math are right? What if someone else is an evil bastard moving the car additionally besides my gold-plated lovely code? My investigation begun for the intruder to my kinematic territory. But nothing. Not a single line sets the coordinates of the `AutomatedCar`, except... those two methods. Those two, `setPosition(IVector)` and `setPosition(int x, int y)`. I checked them. No one uses them, except my code. Not a single invocation from outside of it. So I returned to these two methods. One of them. It was the culprit. It was the hellish evil bastard, containing one of the most hidden bugs I have ever written. There was the lines of otherworldly suffer:
```java
this.setX((int)movement.getXDiff());
this.setY((int)movement.getYDiff());
```
It's right there. Hiding quietly. Enjoying his short lived avenge on our bad design decisions we made on the long road we took. Do your eyes find those demons of bugfixing?

The redemption my kinematic world waited all along:
```java
this.setX((int)round(position.getXDiff()));
this.setY((int)round(position.getYDiff()));
```

# The Solution
The location of the car is stored as X and Y, both being `integer`, although the movement calculation of the car is much more refined and is calculated in `double`. There is a little need to dumbify the accurate coordinates into `int`s. And there is the catch. When the movement vector had a very little, but importantly negative value, then the `double` got always truncated down to the nearest integer, hence the more frame-rate the game has, the faster the car shifts towards negative values when going in certain directions.

# Lesson Learned
Store map locations in games as `double` values or at least `float` in case it is not just a chess or some boardgame. Especially if the given object is moving. Please.

... and of course don't just truncate `double` were a whole number is required. Truncate only intentionally and consider rounding instead.